### PR TITLE
6.0 Deployment target

### DIFF
--- a/ZipKit.xcodeproj/project.pbxproj
+++ b/ZipKit.xcodeproj/project.pbxproj
@@ -692,7 +692,7 @@
 				DSTROOT = /tmp/touchzipkit.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ZipKit/ZipKit-Prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -706,7 +706,7 @@
 				DSTROOT = /tmp/touchzipkit.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ZipKit/ZipKit-Prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
In README you specify the minimum iOS version supported is iOS 6.0, but the deployment target is set to 6.1. Xcode 7 beta complains about using the static library in projects with a deployment target of 6.0 when built with the deployment target set to 6.1.