### PR TITLE
Allow change Compression Level

### DIFF
--- a/ZipKit/ZKFileArchive.h
+++ b/ZipKit/ZKFileArchive.h
@@ -24,5 +24,6 @@
 - (NSInteger) deflateFile:(NSString *)path relativeToPath:(NSString *)basePath usingResourceFork:(BOOL)flag;
 
 @property (assign) BOOL useZip64Extensions;
+@property (atomic) int compressionLevel;
 
 @end

--- a/ZipKit/ZKFileArchive.m
+++ b/ZipKit/ZKFileArchive.m
@@ -525,7 +525,7 @@
 			strm.next_in = Z_NULL;
 			strm.avail_in = 0;
 			strm.total_out = 0;
-			NSInteger ret = deflateInit2(&strm, Z_BEST_COMPRESSION, Z_DEFLATED, -MAX_WBITS, 8, Z_DEFAULT_STRATEGY);
+			NSInteger ret = deflateInit2(&strm, self.compressionLevel, Z_DEFLATED, -MAX_WBITS, 8, Z_DEFAULT_STRATEGY);
 			if (ret == Z_OK) {
 				NSFileHandle *file = [NSFileHandle fileHandleForReadingAtPath:path];
 				NSData *fileData = nil;
@@ -716,6 +716,7 @@
 - (id) init {
 	if (self = [super init])
 		self.useZip64Extensions = NO;
+		self.compressionLevel = Z_BEST_COMPRESSION;
 	return self;
 }
 


### PR DESCRIPTION
This pull request allow developer to manually change according to their need simply by:
`archive.compressionLevel = Z_NO_COMPRESSION` for no compression which is level 0
`archive.compressionLevel = Z_BEST_SPEED` for best speed which is level 1
`archive.compressionLevel = Z_BEST_COMPRESSION` for best compression which is level 9 and default in ZKFileArchive implementation for now
`archive.compressionLevel = Z_DEFAULT_COMPRESSION` for best compression/speed balance which is level 6