### PR TITLE
NSRangeException

### DIFF
--- a/ZipKit/NSData+ZKAdditions.m
+++ b/ZipKit/NSData+ZKAdditions.m
@@ -17,7 +17,9 @@
 - (UInt16) zk_hostInt16OffsetBy:(UInt64 *)offset {
 	UInt16 value;
 	NSUInteger length = sizeof(value);
-	[self getBytes:&value range:NSMakeRange((NSUInteger) * offset, length)];
+    if (sizeof(value) != 0) {
+        [self getBytes:&value range:NSMakeRange((NSUInteger) * offset, length)];
+    }
 	*offset += length;
 	return CFSwapInt16LittleToHost(value);
 }
@@ -25,7 +27,9 @@
 - (UInt32) zk_hostInt32OffsetBy:(UInt64 *)offset {
 	UInt32 value;
 	NSUInteger length = sizeof(value);
-	[self getBytes:&value range:NSMakeRange((NSUInteger) * offset, length)];
+    if (sizeof(value) != 0) {
+        [self getBytes:&value range:NSMakeRange((NSUInteger) * offset, length)];
+    }
 	*offset += length;
 	return CFSwapInt32LittleToHost(value);
 }
@@ -33,7 +37,9 @@
 - (UInt64) zk_hostInt64OffsetBy:(UInt64 *)offset {
 	UInt64 value;
 	NSUInteger length = sizeof(value);
-	[self getBytes:&value range:NSMakeRange((NSUInteger) * offset, length)];
+    if (sizeof(value) != 0) {
+        [self getBytes:&value range:NSMakeRange((NSUInteger) * offset, length)];
+    }
 	*offset += length;
 	return CFSwapInt64LittleToHost(value);
 }

--- a/ZipKit/NSData+ZKAdditions.m
+++ b/ZipKit/NSData+ZKAdditions.m
@@ -17,9 +17,7 @@
 - (UInt16) zk_hostInt16OffsetBy:(UInt64 *)offset {
 	UInt16 value;
 	NSUInteger length = sizeof(value);
-    if (sizeof(value) != 0) {
-        [self getBytes:&value range:NSMakeRange((NSUInteger) * offset, length)];
-    }
+    [self getBytes:&value range:NSMakeRange((NSUInteger) * offset, length)];
 	*offset += length;
 	return CFSwapInt16LittleToHost(value);
 }
@@ -27,9 +25,7 @@
 - (UInt32) zk_hostInt32OffsetBy:(UInt64 *)offset {
 	UInt32 value;
 	NSUInteger length = sizeof(value);
-    if (sizeof(value) != 0) {
-        [self getBytes:&value range:NSMakeRange((NSUInteger) * offset, length)];
-    }
+    [self getBytes:&value range:NSMakeRange((NSUInteger) * offset, length)];
 	*offset += length;
 	return CFSwapInt32LittleToHost(value);
 }
@@ -37,9 +33,7 @@
 - (UInt64) zk_hostInt64OffsetBy:(UInt64 *)offset {
 	UInt64 value;
 	NSUInteger length = sizeof(value);
-    if (sizeof(value) != 0) {
-        [self getBytes:&value range:NSMakeRange((NSUInteger) * offset, length)];
-    }
+    [self getBytes:&value range:NSMakeRange((NSUInteger) * offset, length)];
 	*offset += length;
 	return CFSwapInt64LittleToHost(value);
 }

--- a/ZipKit/NSData+ZKAdditions.m
+++ b/ZipKit/NSData+ZKAdditions.m
@@ -16,7 +16,7 @@
 
 - (UInt16) zk_hostInt16OffsetBy:(UInt64 *)offset {
 	UInt16 value;
-	NSUInteger length = sizeof(value);
+    NSUInteger length = sizeof(value);
     [self getBytes:&value range:NSMakeRange((NSUInteger) * offset, length)];
 	*offset += length;
 	return CFSwapInt16LittleToHost(value);

--- a/ZipKit/ZKCDHeader.m
+++ b/ZipKit/ZKCDHeader.m
@@ -73,7 +73,7 @@
 }
 
 + (ZKCDHeader *) recordWithData:(NSData *)data atOffset:(UInt64)offset {
-	if (!data) return nil;
+	if (!data || data.length < 1) return nil;
 	UInt32 mn = [data zk_hostInt32OffsetBy:&offset];
 	if (mn != ZKCDHeaderMagicNumber) return nil;
 	ZKCDHeader *record = [ZKCDHeader new];

--- a/ZipKit/ZKCDTrailer.m
+++ b/ZipKit/ZKCDTrailer.m
@@ -45,6 +45,7 @@
 }
 
 + (ZKCDTrailer *) recordWithData:(NSData *)data atOffset:(UInt64)offset {
+    if (!data) return nil;
 	UInt32 mn = [data zk_hostInt32OffsetBy:&offset];
 	if (mn != ZKCDTrailerMagicNumber) return nil;
 	ZKCDTrailer *record = [ZKCDTrailer new];

--- a/ZipKit/ZKCDTrailer.m
+++ b/ZipKit/ZKCDTrailer.m
@@ -45,7 +45,7 @@
 }
 
 + (ZKCDTrailer *) recordWithData:(NSData *)data atOffset:(UInt64)offset {
-    if (!data) return nil;
+    if (!data || data.length < 1) return nil;
 	UInt32 mn = [data zk_hostInt32OffsetBy:&offset];
 	if (mn != ZKCDTrailerMagicNumber) return nil;
 	ZKCDTrailer *record = [ZKCDTrailer new];

--- a/ZipKit/ZKCDTrailer64.m
+++ b/ZipKit/ZKCDTrailer64.m
@@ -24,7 +24,7 @@
 }
 
 + (ZKCDTrailer64 *) recordWithData:(NSData *)data atOffset:(UInt64)offset {
-	if (!data) return nil;
+	if (!data || data.length < 1) return nil;
 	UInt32 mn = [data zk_hostInt32OffsetBy:&offset];
 	if (mn != ZKCDTrailer64MagicNumber) return nil;
 	ZKCDTrailer64 *record = [ZKCDTrailer64 new];

--- a/ZipKit/ZKCDTrailer64Locator.m
+++ b/ZipKit/ZKCDTrailer64Locator.m
@@ -21,7 +21,7 @@
 }
 
 + (ZKCDTrailer64Locator *) recordWithData:(NSData *)data atOffset:(UInt64)offset {
-    if (!data) return nil;
+    if (!data || data.length < 1) return nil;
 	UInt32 mn = [data zk_hostInt32OffsetBy:&offset];
 	if (mn != ZKCDTrailer64LocatorMagicNumber) return nil;
 	ZKCDTrailer64Locator *record = [ZKCDTrailer64Locator new];

--- a/ZipKit/ZKCDTrailer64Locator.m
+++ b/ZipKit/ZKCDTrailer64Locator.m
@@ -21,6 +21,7 @@
 }
 
 + (ZKCDTrailer64Locator *) recordWithData:(NSData *)data atOffset:(UInt64)offset {
+    if (!data) return nil;
 	UInt32 mn = [data zk_hostInt32OffsetBy:&offset];
 	if (mn != ZKCDTrailer64LocatorMagicNumber) return nil;
 	ZKCDTrailer64Locator *record = [ZKCDTrailer64Locator new];

--- a/ZipKit/ZKLFHeader.m
+++ b/ZipKit/ZKLFHeader.m
@@ -63,7 +63,7 @@
 }
 
 + (ZKLFHeader *) recordWithData:(NSData *)data atOffset:(UInt64)offset {
-	if (!data) return nil;
+    if (!data || data.length < 1) return nil;
 	UInt32 mn = [data zk_hostInt32OffsetBy:&offset];
 	if (mn != ZKLFHeaderMagicNumber) return nil;
 	ZKLFHeader *record = [ZKLFHeader new];


### PR DESCRIPTION
Reason: [_NSZeroData getBytes:range:]: range {0, 4} exceeds data length 0

App is crashing, reason the range becomes exceeded when the &value bytes is zero, I just added a condition to check &value address is exist or not.

Making change as per the crash report. Attaching Crash report for reference.

Name: NSRangeException
Reason: *** -[_NSZeroData getBytes:range:]: range {0, 4} exceeds data length 0

Crashed Thread:
  | 0 | CoreFoundation 0x0000000182e42d8c __exceptionPreprocess + 224
-- | -- | --
  | 1 | libobjc.A.dylib 0x0000000181ffc5ec objc_exception_throw + 52
  | 2 | CoreFoundation 0x0000000182e42c6c +[NSException raise:format:] + 112
  | 3 | Foundation 0x00000001837b4bb8 -[NSData(NSData) getBytes:range:] + 272
  | 4 | ZipKit 0x000000010289b808 -[NSData(ZKAdditions) zk_hostInt32OffsetBy:] (NSData+ZKAdditions.m:28)
  | 5 | ZipKit 0x00000001028a8df4 +[ZKLFHeader recordWithData:atOffset:] (ZKLFHeader.m:67)
  | 6 | ZipKit 0x00000001028a916c +[ZKLFHeader recordWithArchivePath:atOffset:] (ZKLFHeader.m:95)
  | 7 | ZipKit 0x00000001028a5b10 -[ZKFileArchive inflateFile:toDirectory:] (ZKFileArchive.m:258)
  | 8 | ZipKit 0x00000001028a5684 -[ZKFileArchive inflateToDirectory:usingResourceFork:] (ZKFileArchive.m:225)
  | 9 | ZipKit 0x00000001028a5584 -[ZKFileArchive inflateToDiskUsingResourceFork:] (ZKFileArchive.m:220)
  | 10 |xxxxxx 0x0000000102a90b5c __40+[BundleUpdate updateBundleIfNeeded]_block_invoke_2 (BundleUpdate.m:105)
  | 11 | AFNetworking 0x0000000100a8e114 __64-[AFHTTPRequestOperation setCompletionBlockWithSuccess:failure:]_block_invoke.139 (AFHTTPRequestOperation.m:279)
  | 12 | libdispatch.dylib 0x0000000182734aa0 _dispatch_call_block_and_release + 20
  | 13 | libdispatch.dylib 0x0000000182734a60 _dispatch_client_callout + 12
  | 14 | libdispatch.dylib 0x000000018274165c _dispatch_main_queue_callback_4CF$VARIANT$mp + 1008
  | 15 | CoreFoundation 0x0000000182deb070 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 8
  | 16 | CoreFoundation 0x0000000182de8bc8 __CFRunLoopRun + 2268
  | 17 | CoreFoundation 0x0000000182d08da8 CFRunLoopRunSpecific + 548
  | 18 | GraphicsServices 0x0000000184ced020 GSEventRunModal + 96
  | 19 | UIKit 0x000000018cd25758 UIApplicationMain + 232
  | 20 | xxxxxxx 0x00000001008a5148 main (main.m:14)
  | 21 | libdyld.dylib 0x0000000182799fc0 start + 0


