### PR TITLE
Remove the usage of PCH from ZipKit

### DIFF
--- a/ZipKit.xcodeproj/project.pbxproj
+++ b/ZipKit.xcodeproj/project.pbxproj
@@ -125,7 +125,6 @@
 		CB6F09CE174838FC00F91524 /* ZipKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ZipKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB6F09D6174838FC00F91524 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		CB6F09D9174838FC00F91524 /* ZipKit-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ZipKit-Info.plist"; sourceTree = "<group>"; };
-		CB6F09DD174838FC00F91524 /* ZipKit-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ZipKit-Prefix.pch"; sourceTree = "<group>"; };
 		CB6F09E61748398400F91524 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = /System/Library/Frameworks/CoreServices.framework; sourceTree = "<absolute>"; };
 		CB6F09ED17483A9A00F91524 /* GMAppleDouble+ZKAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "GMAppleDouble+ZKAdditions.h"; sourceTree = "<group>"; };
 		CB6F09EE17483A9A00F91524 /* NSData+ZKAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+ZKAdditions.h"; sourceTree = "<group>"; };
@@ -254,7 +253,6 @@
 			isa = PBXGroup;
 			children = (
 				CB6F09D9174838FC00F91524 /* ZipKit-Info.plist */,
-				CB6F09DD174838FC00F91524 /* ZipKit-Prefix.pch */,
 			);
 			name = "Supporting Files";
 			path = ZipKit;
@@ -673,8 +671,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "ZipKit/ZipKit-Prefix.pch";
 				INFOPLIST_FILE = "ZipKit/ZipKit-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.voodooergonomics.ZipKitFramework;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -690,8 +686,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "ZipKit/ZipKit-Prefix.pch";
 				INFOPLIST_FILE = "ZipKit/ZipKit-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.voodooergonomics.ZipKitFramework;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -703,8 +697,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "ZipKit/ZipKit-Prefix.pch";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = include/ZipKit;
 			};
@@ -714,8 +706,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "ZipKit/ZipKit-Prefix.pch";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = include/ZipKit;
 			};
@@ -725,8 +715,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DSTROOT = /tmp/touchzipkit.dst;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "ZipKit/ZipKit-Prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -739,8 +727,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DSTROOT = /tmp/touchzipkit.dst;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "ZipKit/ZipKit-Prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ZipKit/ZKDefs.h
+++ b/ZipKit/ZKDefs.h
@@ -5,6 +5,8 @@
 //  Created by Karl Moskowski on 01/04/09.
 //
 
+#import <Foundation/Foundation.h>
+
 #define ZK_TARGET_OS_MAC (TARGET_OS_MAC && !(TARGET_OS_EMBEDDED || TARGET_OS_IPHONE))
 #define ZK_TARGET_OS_IPHONE (TARGET_OS_EMBEDDED || TARGET_OS_IPHONE || TARGET_OS_IPHONE_SIMULATOR)
 

--- a/ZipKit/ZipKit-Prefix.pch
+++ b/ZipKit/ZipKit-Prefix.pch
@@ -1,3 +1,0 @@
-#ifdef __OBJC__
-	#import <Foundation/Foundation.h>
-#endif


### PR DESCRIPTION
In at-scale build systems like Buck or Bazel, usage of PCH files is discouraged. Since ZipKit is only one file away from being PCH-free, I took the liberty of pushing it over the edge. :)