### PR TITLE
Fix missing include when using static library on macOS

### DIFF
--- a/ZipKit/GMAppleDouble.h
+++ b/ZipKit/GMAppleDouble.h
@@ -1,0 +1,1 @@
+MacFUSE/GMAppleDouble.h


### PR DESCRIPTION
When using the static library on macOS an error occurs because `ZipKit/GMAppleDouble.h` does not exist. This resolves it simply by adding a symbolic link to point to `MacFUSE/GMAppleDouble.h`.